### PR TITLE
Add runner analytics, trends, and personal records

### DIFF
--- a/flash/ContentView.swift
+++ b/flash/ContentView.swift
@@ -23,17 +23,26 @@ struct ContentView: View {
                 // Show content immediately (with cached data if available)
                 VStack {
                     HStack {
-                        NavigationLink(destination: detailsView(), label: {
+                        NavigationLink(destination: SettingsView(), label: {
                             Image(systemName: "gearshape")
                                 .padding(.leading, 30)
                         })
+                        .accessibilityLabel("Settings")
                         Spacer()
                         Text("swipe to start a run")
                         Spacer()
-                        NavigationLink(destination: runsView(), label: {
-                            Image(systemName: "list.bullet")
-                                .padding(.trailing, 30)
-                        })
+                        HStack(spacing: 18) {
+                            NavigationLink(destination: detailsView(), label: {
+                                Image(systemName: "chart.xyaxis.line")
+                            })
+                            .accessibilityLabel("Analytics")
+
+                            NavigationLink(destination: runsView(), label: {
+                                Image(systemName: "list.bullet")
+                            })
+                            .accessibilityLabel("Run history")
+                        }
+                        .padding(.trailing, 30)
                     }
                     .opacity(0.30)
                     .padding(.top, -10)

--- a/flash/DetailedRun.swift
+++ b/flash/DetailedRun.swift
@@ -105,6 +105,12 @@ struct DetailedRun: View {
         }
         .font(Font.custom("CallingCode-Regular", size: 70))
         .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            Color.flashBackground
+                .ignoresSafeArea()
+        }
+        .foregroundStyle(.white)
         .navigationTitle("Workout Details")
         .toolbarBackground(Color.flashBackground, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)

--- a/flash/DetailedRun.swift
+++ b/flash/DetailedRun.swift
@@ -8,11 +8,13 @@
 import SwiftUI
 import CoreLocation
 import MapKit
+import SwiftData
 
 
 //view when pressing on a run
 struct DetailedRun: View {
     @EnvironmentObject private var manager: HealthManager
+    @Query private var profiles: [RunnerProfile]
     let workout: RunningData
     @State private var displayedWorkout: RunningData
     @State private var region: MKCoordinateRegion
@@ -132,7 +134,10 @@ struct DetailedRun: View {
             isLoadingDetails = true
         }
 
-        let hydratedWorkout = await manager.hydrateRunDetails(displayedWorkout)
+        let maxHR = Double(
+            profiles.first { $0.key == RunnerProfile.singletonKey }?.effectiveMaxHR() ?? 190
+        )
+        let hydratedWorkout = await manager.hydrateRunDetails(displayedWorkout, maxHR: maxHR)
 
         await MainActor.run {
             displayedWorkout = hydratedWorkout

--- a/flash/HealthManager.swift
+++ b/flash/HealthManager.swift
@@ -171,7 +171,7 @@ class HealthManager: ObservableObject {
         healthStore.execute(query)
     }
 
-    private func processWorkout(_ workout: HKWorkout) async -> RunningData? {
+    private func processWorkout(_ workout: HKWorkout, maxHR: Double) async -> RunningData? {
         let stepCount = await getStepCount(for: workout)
         let totalTimeMinutes = workout.duration / 60
         let cadence = totalTimeMinutes > 0 ? stepCount / totalTimeMinutes : 0
@@ -194,7 +194,11 @@ class HealthManager: ObservableObject {
         let heartRateData = await fetchHeartRateTimeSeries(for: workout)
         let cadenceData = await calculateCadenceFromSteps(for: workout)
 
-        let heartRateZones = calculateHeartRateZones(heartRateData: heartRateData, averageHR: heartRate)
+        let heartRateZones = calculateHeartRateZones(
+            heartRateData: heartRateData,
+            averageHR: heartRate,
+            maxHR: maxHR
+        )
 
         let formattedDuration = formatDuration(workout.duration)
         let distance = workout.totalDistance?.doubleValue(for: .meter()) ?? 0.0
@@ -302,7 +306,7 @@ class HealthManager: ObservableObject {
         }
     }
 
-    func hydrateRunDetails(_ run: RunningData) async -> RunningData {
+    func hydrateRunDetails(_ run: RunningData, maxHR: Double) async -> RunningData {
         guard run.route.isEmpty,
               run.heartRateData.isEmpty,
               run.cadenceData.isEmpty,
@@ -312,7 +316,7 @@ class HealthManager: ObservableObject {
             return run
         }
 
-        return await processWorkout(workout) ?? run
+        return await processWorkout(workout, maxHR: maxHR) ?? run
     }
 
     // Method to load more runs (called when user scrolls to bottom)
@@ -520,12 +524,12 @@ class HealthManager: ObservableObject {
 
     // Calculate heart rate zones based on time-series data
     // Standard zones: Zone 1 (50-60%), Zone 2 (60-70%), Zone 3 (70-80%), Zone 4 (80-90%), Zone 5 (90-100%)
-    private func calculateHeartRateZones(heartRateData: [HeartRateDataPoint], averageHR: Double) -> [HeartRateZone] {
-        guard !heartRateData.isEmpty else { return [] }
-
-        // Estimate max heart rate (220 - age), or use highest recorded HR * 1.05 as a fallback
-        let maxHR = heartRateData.map { $0.heartRate }.max() ?? averageHR
-        let estimatedMaxHR = max(maxHR * 1.05, 180.0) // Use 180 as minimum max HR
+    private func calculateHeartRateZones(
+        heartRateData: [HeartRateDataPoint],
+        averageHR: Double,
+        maxHR: Double
+    ) -> [HeartRateZone] {
+        guard !heartRateData.isEmpty, maxHR.isFinite, maxHR > 0 else { return [] }
 
         // Define zones based on % of max HR
         let zones = [
@@ -540,18 +544,18 @@ class HealthManager: ObservableObject {
         let totalDataPoints = Double(heartRateData.count)
 
         for zone in zones {
-            let minHR = estimatedMaxHR * zone.min
-            let maxHR = estimatedMaxHR * zone.max
+            let minHR = maxHR * zone.min
+            let maxZoneHR = maxHR * zone.max
 
             let pointsInZone = heartRateData.filter { dataPoint in
-                dataPoint.heartRate >= minHR && dataPoint.heartRate < maxHR
+                dataPoint.heartRate >= minHR && dataPoint.heartRate < maxZoneHR
             }.count
 
             let percentage = (Double(pointsInZone) / totalDataPoints) * 100.0
 
             let hrZone = HeartRateZone(
                 zone: zone.name,
-                range: "\(Int(minHR))-\(Int(maxHR)) bpm",
+                range: "\(Int(minHR))-\(Int(maxZoneHR)) bpm",
                 percentage: percentage.rounded(toPlaces: 1),
                 color: zone.color
             )

--- a/flash/HistoryStore.swift
+++ b/flash/HistoryStore.swift
@@ -37,7 +37,7 @@ enum RunAggregator {
     }
 
     static func totals(_ runs: [RunSummaryData], in interval: DateInterval) -> RunTotals {
-        totals(runs.filter { interval.contains($0.date) })
+        totals(runs.filter { $0.date >= interval.start && $0.date < interval.end })
     }
 
     /// 12 ordered buckets (month 1...12) for the given year; empty months are zeroed.
@@ -64,6 +64,17 @@ enum RunAggregator {
         runs.filter { $0.distance >= 1000 }
             .sorted { $0.date < $1.date }
             .map { (date: $0.date, paceMinPerKm: ($0.duration / 60.0) / ($0.distance / 1000.0)) }
+    }
+}
+
+extension CachedRunSummary {
+    var aggregateData: RunSummaryData {
+        RunSummaryData(
+            date: date,
+            distance: distance,
+            duration: duration,
+            elevationGain: elevationGain
+        )
     }
 }
 
@@ -130,14 +141,7 @@ final class HistoryStore {
     private func allSummaries() throws -> [RunSummaryData] {
         let descriptor = FetchDescriptor<CachedRunSummary>(sortBy: [SortDescriptor(\.date)])
         let rows = try context.fetch(descriptor)
-        return rows.map {
-            RunSummaryData(
-                date: $0.date,
-                distance: $0.distance,
-                duration: $0.duration,
-                elevationGain: $0.elevationGain
-            )
-        }
+        return rows.map(\.aggregateData)
     }
 
     /// Cheap summary-only HealthKit query — no routes or HR sub-queries. `startDate == nil`

--- a/flash/LocalStore.swift
+++ b/flash/LocalStore.swift
@@ -210,3 +210,29 @@ final class RunnerProfile {
         return 190
     }
 }
+
+@Model
+final class PersonalRecord {
+    @Attribute(.unique) var key: String
+    var value: Double
+    var runUUID: UUID
+    var date: Date
+    var computedAt: Date
+    var isNew: Bool
+
+    init(
+        key: String,
+        value: Double,
+        runUUID: UUID,
+        date: Date,
+        computedAt: Date = Date(),
+        isNew: Bool = false
+    ) {
+        self.key = key
+        self.value = value
+        self.runUUID = runUUID
+        self.date = date
+        self.computedAt = computedAt
+        self.isNew = isNew
+    }
+}

--- a/flash/LocalStore.swift
+++ b/flash/LocalStore.swift
@@ -28,3 +28,185 @@ final class CachedRunSummary {
         self.avgHR = avgHR
     }
 }
+
+enum PreferredDistanceUnit: String, CaseIterable, Hashable, Identifiable {
+    case kilometers
+    case miles
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .kilometers: "Kilometers"
+        case .miles: "Miles"
+        }
+    }
+}
+
+enum TRIMPSex: String, CaseIterable, Hashable, Identifiable {
+    case notSet
+    case female
+    case male
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .notSet: "Not set"
+        case .female: "Female"
+        case .male: "Male"
+        }
+    }
+}
+
+enum RunnerProfileValidationError: LocalizedError, Equatable {
+    case maxHRMustBePositive
+    case restingHRMustBePositive
+    case birthdateCannotBeInFuture
+    case restingHRMustBeBelowMax
+
+    var errorDescription: String? {
+        switch self {
+        case .maxHRMustBePositive:
+            "Maximum heart rate must be greater than zero."
+        case .restingHRMustBePositive:
+            "Resting heart rate must be greater than zero."
+        case .birthdateCannotBeInFuture:
+            "Birthdate cannot be in the future."
+        case .restingHRMustBeBelowMax:
+            "Resting heart rate must be lower than maximum heart rate."
+        }
+    }
+}
+
+struct RunnerProfileValues: Equatable {
+    var maxHR: Int?
+    var restingHR: Int?
+    var birthdate: Date?
+    var trimpSex: TRIMPSex
+    var distanceUnit: PreferredDistanceUnit
+}
+
+@Model
+final class RunnerProfile {
+    static let singletonKey = "runner-profile"
+
+    @Attribute(.unique) var key: String
+    var maxHR: Int?
+    var restingHR: Int?
+    var birthdate: Date?
+    var trimpSexRaw: String
+    var distanceUnitRaw: String
+
+    var trimpSex: TRIMPSex {
+        get { TRIMPSex(rawValue: trimpSexRaw) ?? .notSet }
+        set { trimpSexRaw = newValue.rawValue }
+    }
+
+    var distanceUnit: PreferredDistanceUnit {
+        get { PreferredDistanceUnit(rawValue: distanceUnitRaw) ?? .kilometers }
+        set { distanceUnitRaw = newValue.rawValue }
+    }
+
+    var effectiveRestingHR: Int {
+        restingHR ?? 60
+    }
+
+    init(
+        key: String = RunnerProfile.singletonKey,
+        maxHR: Int? = nil,
+        restingHR: Int? = nil,
+        birthdate: Date? = nil,
+        trimpSexRaw: String = TRIMPSex.notSet.rawValue,
+        distanceUnitRaw: String = PreferredDistanceUnit.kilometers.rawValue
+    ) {
+        self.key = key
+        self.maxHR = maxHR
+        self.restingHR = restingHR
+        self.birthdate = birthdate
+        self.trimpSexRaw = trimpSexRaw
+        self.distanceUnitRaw = distanceUnitRaw
+    }
+
+    func effectiveMaxHR(on date: Date = Date(), calendar: Calendar = .current) -> Int {
+        Self.effectiveMaxHR(maxHR: maxHR, birthdate: birthdate, on: date, calendar: calendar)
+    }
+
+    func validatedValues(on date: Date = Date(), calendar: Calendar = .current) throws -> RunnerProfileValues {
+        try Self.validate(
+            maxHR: maxHR,
+            restingHR: restingHR,
+            birthdate: birthdate,
+            on: date,
+            calendar: calendar
+        )
+
+        return values
+    }
+
+    var values: RunnerProfileValues {
+        RunnerProfileValues(
+            maxHR: maxHR,
+            restingHR: restingHR,
+            birthdate: birthdate,
+            trimpSex: trimpSex,
+            distanceUnit: distanceUnit
+        )
+    }
+
+    func apply(_ values: RunnerProfileValues) {
+        maxHR = values.maxHR
+        restingHR = values.restingHR
+        birthdate = values.birthdate
+        trimpSex = values.trimpSex
+        distanceUnit = values.distanceUnit
+    }
+
+    static func validate(
+        maxHR: Int?,
+        restingHR: Int?,
+        birthdate: Date?,
+        on date: Date = Date(),
+        calendar: Calendar = .current
+    ) throws {
+        if let maxHR, maxHR <= 0 {
+            throw RunnerProfileValidationError.maxHRMustBePositive
+        }
+        if let restingHR, restingHR <= 0 {
+            throw RunnerProfileValidationError.restingHRMustBePositive
+        }
+        if let birthdate, birthdate > date {
+            throw RunnerProfileValidationError.birthdateCannotBeInFuture
+        }
+
+        let effectiveMaxHR = Self.effectiveMaxHR(
+            maxHR: maxHR,
+            birthdate: birthdate,
+            on: date,
+            calendar: calendar
+        )
+        if let restingHR, restingHR >= effectiveMaxHR {
+            throw RunnerProfileValidationError.restingHRMustBeBelowMax
+        }
+    }
+
+    private static func effectiveMaxHR(
+        maxHR: Int?,
+        birthdate: Date?,
+        on date: Date,
+        calendar: Calendar
+    ) -> Int {
+        if let maxHR {
+            return maxHR
+        }
+        if let birthdate,
+           birthdate <= date,
+           let age = calendar.dateComponents([.year], from: birthdate, to: date).year {
+            let ageBasedMax = 220 - age
+            if ageBasedMax > 0 {
+                return ageBasedMax
+            }
+        }
+        return 190
+    }
+}

--- a/flash/PRView.swift
+++ b/flash/PRView.swift
@@ -1,0 +1,175 @@
+import SwiftData
+import SwiftUI
+
+private struct RecordRunSignature: Equatable {
+    let uuid: UUID
+    let date: Date
+    let distance: Double
+    let duration: Double
+    let elevation: Double
+}
+
+struct PRView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \PersonalRecord.key) private var records: [PersonalRecord]
+    @Query(sort: \CachedRunSummary.date) private var cachedRuns: [CachedRunSummary]
+    @Query private var profiles: [RunnerProfile]
+
+    @State private var isComputing = false
+    @State private var errorMessage: String?
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
+
+    private var inputSignature: [RecordRunSignature] {
+        cachedRuns.map {
+            RecordRunSignature(
+                uuid: $0.healthKitUUID,
+                date: $0.date,
+                distance: $0.distance,
+                duration: $0.duration,
+                elevation: $0.elevationGain
+            )
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.flashBackground
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    if isComputing && records.isEmpty {
+                        HStack {
+                            ProgressView()
+                                .tint(.white)
+                            Text("Computing records…")
+                        }
+                        .font(Font.custom("CallingCode-Regular", size: 14))
+                        .foregroundStyle(.white.opacity(0.7))
+                    }
+
+                    recordCard(
+                        title: "Longest run",
+                        key: PersonalRecordKey.longest
+                    )
+                    recordCard(
+                        title: "Fastest run",
+                        key: PersonalRecordKey.fastest
+                    )
+                    recordCard(
+                        title: "Most elevation",
+                        key: PersonalRecordKey.elevation
+                    )
+
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(Font.custom("CallingCode-Regular", size: 14))
+                            .foregroundStyle(.red)
+                    }
+                }
+                .padding()
+            }
+        }
+        .foregroundStyle(.white)
+        .navigationTitle("Personal Records")
+        .toolbarBackground(Color.flashBackground, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task(id: inputSignature) {
+            await recomputeRecords()
+        }
+    }
+
+    @ViewBuilder
+    private func recordCard(title: String, key: String) -> some View {
+        let record = records.first { $0.key == key }
+        let run = record.flatMap { record in
+            cachedRuns.first { $0.healthKitUUID == record.runUUID }
+        }
+
+        if let record, let run {
+            NavigationLink {
+                DetailedRun(workout: RunSummaryAdapter.runningData(from: run))
+            } label: {
+                recordLabel(title: title, record: record)
+            }
+            .buttonStyle(.plain)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(Font.custom("CallingCode-Regular", size: 20))
+                Text(cachedRuns.isEmpty ? "No runs yet" : "No qualifying run")
+                    .font(Font.custom("CallingCode-Regular", size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .recordCardStyle()
+        }
+    }
+
+    private func recordLabel(title: String, record: PersonalRecord) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text(title)
+                    .font(Font.custom("CallingCode-Regular", size: 20))
+                Spacer()
+                if record.isNew {
+                    Text("NEW PR")
+                        .font(Font.custom("CallingCode-Regular", size: 11))
+                        .foregroundStyle(.green)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.4))
+            }
+
+            Text(valueText(for: record))
+                .font(Font.custom("CallingCode-Regular", size: 28))
+
+            Text(record.date.formatted(.dateTime.day().month(.wide).year()))
+                .font(Font.custom("CallingCode-Regular", size: 13))
+                .foregroundStyle(.white.opacity(0.6))
+        }
+        .recordCardStyle()
+    }
+
+    private func valueText(for record: PersonalRecord) -> String {
+        switch record.key {
+        case PersonalRecordKey.longest:
+            unitPresentation.distanceText(fromMeters: record.value)
+        case PersonalRecordKey.fastest:
+            unitPresentation.paceText(fromMinutesPerKilometer: record.value / 60)
+        case PersonalRecordKey.elevation:
+            unitPresentation.elevationText(fromMeters: record.value)
+        default:
+            "N/A"
+        }
+    }
+
+    @MainActor
+    private func recomputeRecords() async {
+        isComputing = true
+        defer { isComputing = false }
+
+        do {
+            try PersonalRecordStore(context: modelContext)
+                .recomputeWholeRunRecords(from: cachedRuns)
+            errorMessage = nil
+        } catch {
+            errorMessage = "Could not update records: \(error.localizedDescription)"
+        }
+    }
+}
+
+private extension View {
+    func recordCardStyle() -> some View {
+        padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.gray.opacity(0.18))
+            .cornerRadius(8)
+    }
+}

--- a/flash/PersonalRecords.swift
+++ b/flash/PersonalRecords.swift
@@ -1,0 +1,191 @@
+import Foundation
+import SwiftData
+
+enum PersonalRecordKey {
+    static let longest = "whole.longest"
+    static let fastest = "whole.fastest"
+    static let elevation = "whole.elevation"
+
+    static let wholeRunKeys = [longest, fastest, elevation]
+}
+
+struct PersonalRecordInput {
+    let runUUID: UUID
+    let date: Date
+    let distance: Double
+    let duration: Double
+    let elevationGain: Double
+}
+
+struct PersonalRecordCandidate: Equatable {
+    let key: String
+    let value: Double
+    let runUUID: UUID
+    let date: Date
+}
+
+enum PersonalRecordEngine {
+    static func wholeRunRecords(
+        from inputs: [PersonalRecordInput]
+    ) -> [String: PersonalRecordCandidate] {
+        var records: [String: PersonalRecordCandidate] = [:]
+
+        for input in inputs {
+            if input.distance.isFinite, input.distance > 0 {
+                merge(
+                    PersonalRecordCandidate(
+                        key: PersonalRecordKey.longest,
+                        value: input.distance,
+                        runUUID: input.runUUID,
+                        date: input.date
+                    ),
+                    into: &records
+                )
+            }
+
+            if input.distance.isFinite,
+               input.distance >= 1_000,
+               input.duration.isFinite,
+               input.duration > 0 {
+                let secondsPerKilometer = input.duration / (input.distance / 1_000)
+                if secondsPerKilometer.isFinite, secondsPerKilometer > 0 {
+                    merge(
+                        PersonalRecordCandidate(
+                            key: PersonalRecordKey.fastest,
+                            value: secondsPerKilometer,
+                            runUUID: input.runUUID,
+                            date: input.date
+                        ),
+                        into: &records
+                    )
+                }
+            }
+
+            if input.elevationGain.isFinite, input.elevationGain >= 0 {
+                merge(
+                    PersonalRecordCandidate(
+                        key: PersonalRecordKey.elevation,
+                        value: input.elevationGain,
+                        runUUID: input.runUUID,
+                        date: input.date
+                    ),
+                    into: &records
+                )
+            }
+        }
+
+        return records
+    }
+
+    static func merge(
+        _ candidate: PersonalRecordCandidate,
+        into records: inout [String: PersonalRecordCandidate]
+    ) {
+        guard let existing = records[candidate.key] else {
+            records[candidate.key] = candidate
+            return
+        }
+
+        if isBetter(candidate, than: existing) {
+            records[candidate.key] = candidate
+        }
+    }
+
+    static func isBetter(
+        _ candidate: PersonalRecordCandidate,
+        than existing: PersonalRecordCandidate
+    ) -> Bool {
+        guard candidate.key == existing.key else { return false }
+
+        if candidate.value != existing.value {
+            return isMetricImprovement(
+                key: candidate.key,
+                newValue: candidate.value,
+                oldValue: existing.value
+            )
+        }
+        if candidate.date != existing.date {
+            return candidate.date < existing.date
+        }
+        return candidate.runUUID.uuidString < existing.runUUID.uuidString
+    }
+
+    static func isMetricImprovement(key: String, newValue: Double, oldValue: Double) -> Bool {
+        guard newValue.isFinite, oldValue.isFinite else { return false }
+        switch key {
+        case PersonalRecordKey.longest, PersonalRecordKey.elevation:
+            return newValue > oldValue
+        case PersonalRecordKey.fastest:
+            return newValue > 0 && newValue < oldValue
+        default:
+            return key.hasPrefix("distance.") && newValue > 0 && newValue < oldValue
+        }
+    }
+}
+
+@MainActor
+final class PersonalRecordStore {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    func recomputeWholeRunRecords(from rows: [CachedRunSummary], now: Date = Date()) throws {
+        let inputs = rows.map {
+            PersonalRecordInput(
+                runUUID: $0.healthKitUUID,
+                date: $0.date,
+                distance: $0.distance,
+                duration: $0.duration,
+                elevationGain: $0.elevationGain
+            )
+        }
+        let candidates = PersonalRecordEngine.wholeRunRecords(from: inputs)
+        let existingRecords = try context.fetch(FetchDescriptor<PersonalRecord>())
+        var existingByKey = Dictionary(
+            existingRecords.map { ($0.key, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for key in PersonalRecordKey.wholeRunKeys {
+            guard let candidate = candidates[key] else {
+                if let staleRecord = existingByKey.removeValue(forKey: key) {
+                    context.delete(staleRecord)
+                }
+                continue
+            }
+
+            if let record = existingByKey[key] {
+                let selectionChanged = record.value != candidate.value
+                    || record.runUUID != candidate.runUUID
+                    || record.date != candidate.date
+                guard selectionChanged else { continue }
+
+                let improved = PersonalRecordEngine.isMetricImprovement(
+                    key: key,
+                    newValue: candidate.value,
+                    oldValue: record.value
+                )
+                record.value = candidate.value
+                record.runUUID = candidate.runUUID
+                record.date = candidate.date
+                record.computedAt = now
+                record.isNew = improved
+            } else {
+                context.insert(
+                    PersonalRecord(
+                        key: candidate.key,
+                        value: candidate.value,
+                        runUUID: candidate.runUUID,
+                        date: candidate.date,
+                        computedAt: now,
+                        isNew: false
+                    )
+                )
+            }
+        }
+
+        try context.save()
+    }
+}

--- a/flash/RunSummaryAdapter.swift
+++ b/flash/RunSummaryAdapter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+enum RunSummaryAdapter {
+    static func runningData(from summary: CachedRunSummary) -> RunningData {
+        let paceMinutesPerKilometer: Double
+        if summary.distance > 0, summary.duration > 0 {
+            paceMinutesPerKilometer = (summary.duration / 60) / (summary.distance / 1_000)
+        } else {
+            paceMinutesPerKilometer = 0
+        }
+        let formattedDuration = RunUnitPresentation.durationText(summary.duration)
+
+        return RunningData(
+            date: summary.date,
+            distance: summary.distance,
+            cadence: 0,
+            power: 0,
+            pace: paceMinutesPerKilometer,
+            formattedPace: paceText(paceMinutesPerKilometer),
+            heartRate: summary.avgHR ?? 0,
+            strideLength: 0,
+            verticalOscillation: 0,
+            groundContactTime: 0,
+            duration: summary.duration,
+            formattedDuration: formattedDuration,
+            elevation: summary.elevationGain,
+            activeCalories: summary.calories,
+            route: [],
+            formatDuration: formattedDuration,
+            pacePerKM: [],
+            heartRateData: [],
+            cadenceData: [],
+            heartRateZones: [],
+            healthKitUUID: summary.healthKitUUID
+        )
+    }
+
+    private static func paceText(_ paceMinutesPerKilometer: Double) -> String {
+        guard paceMinutesPerKilometer.isFinite, paceMinutesPerKilometer > 0 else {
+            return "N/A"
+        }
+        let totalSeconds = Int((paceMinutesPerKilometer * 60).rounded())
+        return String(format: "%d:%02d/km", totalSeconds / 60, totalSeconds % 60)
+    }
+}

--- a/flash/SettingsView.swift
+++ b/flash/SettingsView.swift
@@ -1,0 +1,279 @@
+import SwiftData
+import SwiftUI
+
+enum RunnerProfileDraftError: LocalizedError, Equatable {
+    case maxHRMustBeWholeNumber
+    case restingHRMustBeWholeNumber
+
+    var errorDescription: String? {
+        switch self {
+        case .maxHRMustBeWholeNumber:
+            "Maximum heart rate must be a whole number."
+        case .restingHRMustBeWholeNumber:
+            "Resting heart rate must be a whole number."
+        }
+    }
+}
+
+struct RunnerProfileDraft {
+    var maxHRText = ""
+    var restingHRText = ""
+    var includesBirthdate = false
+    var birthdate = Calendar.current.date(byAdding: .year, value: -30, to: Date()) ?? Date()
+    var trimpSex = TRIMPSex.notSet
+    var distanceUnit = PreferredDistanceUnit.kilometers
+
+    init() {}
+
+    init(profile: RunnerProfile) {
+        maxHRText = profile.maxHR.map(String.init) ?? ""
+        restingHRText = profile.restingHR.map(String.init) ?? ""
+        includesBirthdate = profile.birthdate != nil
+        birthdate = profile.birthdate
+            ?? Calendar.current.date(byAdding: .year, value: -30, to: Date())
+            ?? Date()
+        trimpSex = profile.trimpSex
+        distanceUnit = profile.distanceUnit
+    }
+
+    func validatedValues(on date: Date = Date(), calendar: Calendar = .current) throws -> RunnerProfileValues {
+        let maxHR = try parseOptionalHeartRate(
+            maxHRText,
+            invalidError: .maxHRMustBeWholeNumber
+        )
+        let restingHR = try parseOptionalHeartRate(
+            restingHRText,
+            invalidError: .restingHRMustBeWholeNumber
+        )
+        let selectedBirthdate = includesBirthdate ? birthdate : nil
+
+        try RunnerProfile.validate(
+            maxHR: maxHR,
+            restingHR: restingHR,
+            birthdate: selectedBirthdate,
+            on: date,
+            calendar: calendar
+        )
+
+        return RunnerProfileValues(
+            maxHR: maxHR,
+            restingHR: restingHR,
+            birthdate: selectedBirthdate,
+            trimpSex: trimpSex,
+            distanceUnit: distanceUnit
+        )
+    }
+
+    private func parseOptionalHeartRate(
+        _ text: String,
+        invalidError: RunnerProfileDraftError
+    ) throws -> Int? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let value = Int(trimmed) else { throw invalidError }
+        return value
+    }
+}
+
+struct SettingsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \RunnerProfile.key) private var profiles: [RunnerProfile]
+
+    @State private var draft = RunnerProfileDraft()
+    @State private var hasLoadedProfile = false
+    @State private var isSaving = false
+    @State private var statusMessage: String?
+    @State private var statusIsError = false
+
+    private var profile: RunnerProfile? {
+        profiles.first { $0.key == RunnerProfile.singletonKey }
+    }
+
+    private var validationMessage: String? {
+        do {
+            _ = try draft.validatedValues()
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.flashBackground
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    settingsCard(title: "Heart rate") {
+                        heartRateField("Maximum", text: $draft.maxHRText, placeholder: "Auto")
+                        Divider().overlay(Color.white.opacity(0.12))
+                        heartRateField("Resting", text: $draft.restingHRText, placeholder: "60")
+                    }
+
+                    settingsCard(title: "Birthdate") {
+                        Toggle("Use birthdate for max HR", isOn: $draft.includesBirthdate)
+                            .tint(.blue)
+
+                        if draft.includesBirthdate {
+                            DatePicker(
+                                "Birthdate",
+                                selection: $draft.birthdate,
+                                in: ...Date(),
+                                displayedComponents: .date
+                            )
+                            .datePickerStyle(.compact)
+                        }
+                    }
+
+                    settingsCard(title: "Training load") {
+                        Text("Used later to calculate personalized training load.")
+                            .font(Font.custom("CallingCode-Regular", size: 13))
+                            .foregroundStyle(.white.opacity(0.6))
+
+                        Picker("TRIMP sex", selection: $draft.trimpSex) {
+                            ForEach(TRIMPSex.allCases) { value in
+                                Text(value.title).tag(value)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    settingsCard(title: "Distance") {
+                        Picker("Preferred unit", selection: $draft.distanceUnit) {
+                            ForEach(PreferredDistanceUnit.allCases) { unit in
+                                Text(unit.title).tag(unit)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    if let validationMessage {
+                        Text(validationMessage)
+                            .font(Font.custom("CallingCode-Regular", size: 14))
+                            .foregroundStyle(.red)
+                    } else if let statusMessage {
+                        Text(statusMessage)
+                            .font(Font.custom("CallingCode-Regular", size: 14))
+                            .foregroundStyle(statusIsError ? Color.red : Color.green)
+                    }
+
+                    Button(action: save) {
+                        HStack {
+                            Spacer()
+                            if isSaving {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text("Save")
+                            }
+                            Spacer()
+                        }
+                        .font(Font.custom("CallingCode-Regular", size: 20))
+                        .padding()
+                        .background(Color.gray.opacity(0.25))
+                        .cornerRadius(8)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(profile == nil || validationMessage != nil || isSaving)
+                    .opacity(profile == nil || validationMessage != nil || isSaving ? 0.5 : 1)
+                }
+                .padding()
+            }
+        }
+        .foregroundStyle(.white)
+        .navigationTitle("Settings")
+        .toolbarBackground(Color.flashBackground, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            ensureProfileExists()
+        }
+    }
+
+    private func settingsCard<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(title)
+                .font(Font.custom("CallingCode-Regular", size: 18))
+                .foregroundStyle(.white.opacity(0.7))
+
+            VStack(alignment: .leading, spacing: 14) {
+                content()
+            }
+            .font(Font.custom("CallingCode-Regular", size: 16))
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.gray.opacity(0.18))
+            .cornerRadius(8)
+        }
+    }
+
+    private func heartRateField(
+        _ title: String,
+        text: Binding<String>,
+        placeholder: String
+    ) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            TextField(placeholder, text: text)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.trailing)
+                .frame(width: 100)
+            Text("bpm")
+                .foregroundStyle(.white.opacity(0.6))
+        }
+    }
+
+    @MainActor
+    private func ensureProfileExists() {
+        guard !hasLoadedProfile else { return }
+
+        if let profile {
+            draft = RunnerProfileDraft(profile: profile)
+            hasLoadedProfile = true
+            return
+        }
+
+        let newProfile = RunnerProfile()
+        modelContext.insert(newProfile)
+
+        do {
+            try modelContext.save()
+            draft = RunnerProfileDraft(profile: newProfile)
+            hasLoadedProfile = true
+        } catch {
+            modelContext.delete(newProfile)
+            statusMessage = "Could not create settings: \(error.localizedDescription)"
+            statusIsError = true
+        }
+    }
+
+    @MainActor
+    private func save() {
+        guard let profile else { return }
+
+        do {
+            let values = try draft.validatedValues()
+            let previousValues = profile.values
+            isSaving = true
+            profile.apply(values)
+
+            do {
+                try modelContext.save()
+                statusMessage = "Settings saved."
+                statusIsError = false
+            } catch {
+                profile.apply(previousValues)
+                statusMessage = "Could not save settings: \(error.localizedDescription)"
+                statusIsError = true
+            }
+            isSaving = false
+        } catch {
+            statusMessage = error.localizedDescription
+            statusIsError = true
+        }
+    }
+}

--- a/flash/TrendsView.swift
+++ b/flash/TrendsView.swift
@@ -1,0 +1,346 @@
+import Charts
+import SwiftData
+import SwiftUI
+
+enum TrendsPeriod: String, CaseIterable, Identifiable {
+    case month
+    case year
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .month: "Month"
+        case .year: "Year"
+        }
+    }
+
+    var calendarComponent: Calendar.Component {
+        switch self {
+        case .month: .month
+        case .year: .year
+        }
+    }
+}
+
+struct MonthTrendComparison: Equatable {
+    let current: RunTotals
+    let previous: RunTotals
+
+    var distanceDelta: Double? {
+        previous.distance > 0 ? current.distance - previous.distance : nil
+    }
+
+    var paceDelta: Double? {
+        guard previous.distance > 0, current.avgPace > 0, previous.avgPace > 0 else {
+            return nil
+        }
+        return current.avgPace - previous.avgPace
+    }
+}
+
+enum TrendAnalytics {
+    static func interval(
+        for period: TrendsPeriod,
+        containing date: Date,
+        calendar: Calendar = .current
+    ) -> DateInterval {
+        calendar.dateInterval(of: period.calendarComponent, for: date)
+            ?? DateInterval(start: date, end: date)
+    }
+
+    static func currentAndPreviousMonthIntervals(
+        containing date: Date,
+        calendar: Calendar = .current
+    ) -> (current: DateInterval, previous: DateInterval) {
+        let current = interval(for: .month, containing: date, calendar: calendar)
+        let previousStart = calendar.date(byAdding: .month, value: -1, to: current.start)
+            ?? current.start
+        return (
+            current,
+            DateInterval(start: previousStart, end: current.start)
+        )
+    }
+
+    static func monthComparison(
+        _ runs: [RunSummaryData],
+        containing date: Date = Date(),
+        calendar: Calendar = .current
+    ) -> MonthTrendComparison {
+        let intervals = currentAndPreviousMonthIntervals(containing: date, calendar: calendar)
+        return MonthTrendComparison(
+            current: RunAggregator.totals(runs, in: intervals.current),
+            previous: RunAggregator.totals(runs, in: intervals.previous)
+        )
+    }
+}
+
+struct RunUnitPresentation {
+    let unit: PreferredDistanceUnit
+
+    var distanceLabel: String {
+        unit == .miles ? "mi" : "km"
+    }
+
+    var paceLabel: String {
+        unit == .miles ? "/mi" : "/km"
+    }
+
+    var elevationLabel: String {
+        unit == .miles ? "ft" : "m"
+    }
+
+    func distance(fromMeters meters: Double) -> Double {
+        meters / (unit == .miles ? 1_609.344 : 1_000)
+    }
+
+    func elevation(fromMeters meters: Double) -> Double {
+        unit == .miles ? meters * 3.28084 : meters
+    }
+
+    func pace(fromMinutesPerKilometer pace: Double) -> Double {
+        unit == .miles ? pace * 1.609344 : pace
+    }
+
+    func distanceText(fromMeters meters: Double, signed: Bool = false) -> String {
+        let value = distance(fromMeters: meters)
+        return String(format: signed ? "%+.2f %@" : "%.2f %@", value, distanceLabel)
+    }
+
+    func elevationText(fromMeters meters: Double) -> String {
+        String(format: "%.0f %@", elevation(fromMeters: meters), elevationLabel)
+    }
+
+    func paceText(fromMinutesPerKilometer pace: Double) -> String {
+        guard pace.isFinite, pace > 0 else { return "N/A" }
+        return Self.clockText(minutes: self.pace(fromMinutesPerKilometer: pace)) + paceLabel
+    }
+
+    func paceDeltaText(fromMinutesPerKilometer delta: Double) -> String {
+        guard delta.isFinite else { return "Unavailable" }
+        let direction = delta < 0 ? "faster" : delta > 0 ? "slower" : "unchanged"
+        guard delta != 0 else { return direction }
+        let convertedDelta = abs(pace(fromMinutesPerKilometer: delta))
+        return "\(Self.clockText(minutes: convertedDelta))\(paceLabel) \(direction)"
+    }
+
+    static func durationText(_ duration: TimeInterval) -> String {
+        guard duration.isFinite, duration >= 0 else { return "N/A" }
+        let seconds = Int(duration.rounded())
+        let hours = seconds / 3_600
+        let minutes = (seconds % 3_600) / 60
+        let remainingSeconds = seconds % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, remainingSeconds)
+    }
+
+    private static func clockText(minutes: Double) -> String {
+        let totalSeconds = Int((minutes * 60).rounded())
+        return String(format: "%d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+}
+
+private struct PaceTrendPoint: Identifiable {
+    let id: Int
+    let date: Date
+    let pace: Double
+}
+
+struct TrendsView: View {
+    @Query(sort: \CachedRunSummary.date) private var cachedRuns: [CachedRunSummary]
+    @Query private var profiles: [RunnerProfile]
+
+    @State private var selectedPeriod = TrendsPeriod.month
+
+    private var summaries: [RunSummaryData] {
+        cachedRuns.map(\.aggregateData)
+    }
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
+
+    private var selectedTotals: RunTotals {
+        let interval = TrendAnalytics.interval(for: selectedPeriod, containing: Date())
+        return RunAggregator.totals(summaries, in: interval)
+    }
+
+    private var monthComparison: MonthTrendComparison {
+        TrendAnalytics.monthComparison(summaries)
+    }
+
+    private var pacePoints: [PaceTrendPoint] {
+        RunAggregator.paceSeries(summaries).enumerated().map { index, point in
+            PaceTrendPoint(
+                id: index,
+                date: point.date,
+                pace: unitPresentation.pace(fromMinutesPerKilometer: point.paceMinPerKm)
+            )
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.flashBackground
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    Picker("Period", selection: $selectedPeriod) {
+                        ForEach(TrendsPeriod.allCases) { period in
+                            Text(period.title).tag(period)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    periodSummary
+                    monthComparisonCard
+                    paceChart
+                }
+                .padding()
+            }
+        }
+        .foregroundStyle(.white)
+        .navigationTitle("Trends")
+        .toolbarBackground(Color.flashBackground, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    private var periodSummary: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(periodTitle)
+                .font(Font.custom("CallingCode-Regular", size: 24))
+
+            metricRow(
+                title: "Distance",
+                value: unitPresentation.distanceText(fromMeters: selectedTotals.distance)
+            )
+            metricRow(title: "Time", value: RunUnitPresentation.durationText(selectedTotals.duration))
+            metricRow(title: "Runs", value: String(selectedTotals.count))
+            metricRow(
+                title: "Elevation",
+                value: unitPresentation.elevationText(fromMeters: selectedTotals.elevation)
+            )
+            metricRow(
+                title: "Average pace",
+                value: unitPresentation.paceText(fromMinutesPerKilometer: selectedTotals.avgPace)
+            )
+        }
+        .analyticsCard()
+    }
+
+    private var monthComparisonCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("This month vs last month")
+                .font(Font.custom("CallingCode-Regular", size: 24))
+
+            if let distanceDelta = monthComparison.distanceDelta {
+                metricRow(
+                    title: "Distance",
+                    value: unitPresentation.distanceText(
+                        fromMeters: distanceDelta,
+                        signed: true
+                    )
+                )
+
+                if let paceDelta = monthComparison.paceDelta {
+                    metricRow(
+                        title: "Average pace",
+                        value: unitPresentation.paceDeltaText(
+                            fromMinutesPerKilometer: paceDelta
+                        )
+                    )
+                } else {
+                    metricRow(title: "Average pace", value: "Unavailable")
+                }
+            } else {
+                Text("No previous-month distance to compare yet.")
+                    .font(Font.custom("CallingCode-Regular", size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+        }
+        .analyticsCard()
+    }
+
+    private var paceChart: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Pace over time")
+                .font(Font.custom("CallingCode-Regular", size: 24))
+
+            if pacePoints.isEmpty {
+                Text("Run at least 1 km to start a pace trend.")
+                    .font(Font.custom("CallingCode-Regular", size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+            } else {
+                Chart(pacePoints) { point in
+                    LineMark(
+                        x: .value("Date", point.date),
+                        y: .value("Pace", point.pace)
+                    )
+                    .foregroundStyle(Color.blue)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+
+                    PointMark(
+                        x: .value("Date", point.date),
+                        y: .value("Pace", point.pace)
+                    )
+                    .foregroundStyle(Color.blue)
+                }
+                .chartXAxis {
+                    AxisMarks(position: .bottom) { _ in
+                        AxisGridLine().foregroundStyle(Color.white.opacity(0.1))
+                        AxisTick().foregroundStyle(.clear)
+                        AxisValueLabel(format: .dateTime.month(.abbreviated).year(.twoDigits))
+                            .foregroundStyle(.white.opacity(0.6))
+                            .font(Font.custom("CallingCode-Regular", size: 11))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { _ in
+                        AxisGridLine().foregroundStyle(Color.white.opacity(0.1))
+                        AxisValueLabel()
+                            .foregroundStyle(.white.opacity(0.6))
+                            .font(Font.custom("CallingCode-Regular", size: 11))
+                    }
+                }
+                .frame(height: 240)
+
+                Text("Minutes\(unitPresentation.paceLabel) • runs shorter than 1 km excluded")
+                    .font(Font.custom("CallingCode-Regular", size: 12))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+        }
+        .analyticsCard()
+    }
+
+    private var periodTitle: String {
+        switch selectedPeriod {
+        case .month:
+            Date().formatted(.dateTime.month(.wide).year())
+        case .year:
+            Date().formatted(.dateTime.year())
+        }
+    }
+
+    private func metricRow(title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .foregroundStyle(.white.opacity(0.65))
+            Spacer()
+            Text(value)
+                .multilineTextAlignment(.trailing)
+        }
+        .font(Font.custom("CallingCode-Regular", size: 16))
+    }
+}
+
+private extension View {
+    func analyticsCard() -> some View {
+        padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.gray.opacity(0.18))
+            .cornerRadius(8)
+    }
+}

--- a/flash/detailsView.swift
+++ b/flash/detailsView.swift
@@ -56,6 +56,17 @@ struct detailsView: View {
                 
                 VStack(spacing: 15) {
                     NavigationLink {
+                        PRView()
+                    } label: {
+                        Text("Personal Records")
+                            .font(Font.custom("CallingCode-Regular", size: 24))
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.gray.opacity(0.2))
+                            .cornerRadius(8)
+                    }
+
+                    NavigationLink {
                         TrendsView()
                     } label: {
                         Text("Trends")

--- a/flash/detailsView.swift
+++ b/flash/detailsView.swift
@@ -5,41 +5,46 @@
 //  Created by abbe on 2024-11-21.
 //
 
+import SwiftData
 import SwiftUI
 
 struct detailsView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var manager: HealthManager
+    @Query(sort: \CachedRunSummary.date) private var cachedRuns: [CachedRunSummary]
+    @Query private var profiles: [RunnerProfile]
     
-    // Calculate yearly stats
-    private var yearlyStats: (distance: Double, duration: TimeInterval, pace: Double) {
-        let runs = manager.allRuns
-        let totalDistance = runs.reduce(0.0) { $0 + $1.distance } / 1000 // Convert to km
-        let totalDuration = runs.reduce(0.0) { $0 + $1.duration }
-        let averagePace = totalDistance > 0 ? totalDuration / 60 / totalDistance : 0 // Convert to min/km
-        
-        return (totalDistance, totalDuration, averagePace)
+    private var allTimeTotals: RunTotals {
+        RunAggregator.totals(cachedRuns.map(\.aggregateData))
+    }
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
     }
     
     var body: some View {
         ZStack{
             Color.flashBackground
                 .ignoresSafeArea()
-            VStack(alignment: .leading, spacing: 20) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
                 VStack{
                     
-                    Text(formatDuration(yearlyStats.duration))
+                    Text(RunUnitPresentation.durationText(allTimeTotals.duration))
                         .frame(maxWidth: 300, alignment: .leading)
                     Text("Time")
                         .frame(maxWidth: 300, alignment: .leading)
                     
-                    Text(formatPace(yearlyStats.pace))
+                    Text(unitPresentation.paceText(fromMinutesPerKilometer: allTimeTotals.avgPace))
                         .frame(maxWidth: 300, alignment: .leading)
                         .padding(.top, 3)
                     Text("Average Pace")
                         .frame(maxWidth: 300, alignment: .leading)
                     
-                    Text(String(format: "%.2f km", yearlyStats.distance))
+                    Text(unitPresentation.distanceText(fromMeters: allTimeTotals.distance))
                         .frame(maxWidth: 300, alignment: .leading)
                         .padding(.top, 3)
                     Text("Total Distance")
@@ -49,9 +54,18 @@ struct detailsView: View {
                 .padding(.top, 30)
                 .padding(.horizontal)
                 
-                Spacer()
-    
                 VStack(spacing: 15) {
+                    NavigationLink {
+                        TrendsView()
+                    } label: {
+                        Text("Trends")
+                            .font(Font.custom("CallingCode-Regular", size: 24))
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.gray.opacity(0.2))
+                            .cornerRadius(8)
+                    }
+
                     NavigationLink {
                         RunListPage(
                             title: "Longest Runs",
@@ -109,30 +123,13 @@ struct detailsView: View {
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 30)
+                }
             }
             .padding()
             .foregroundColor(.white)
         }
         .toolbarBackground(Color.flashBackground, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
-    }
-    
-    // Helper function to format duration
-    private func formatDuration(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = (Int(duration) % 3600) / 60
-        let seconds = Int(duration) % 60
-        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-    }
-    
-    // Helper function to format pace
-    private func formatPace(_ pace: Double) -> String {
-        guard pace.isFinite && !pace.isNaN && pace > 0 else {
-            return "N/A"
-        }
-        let minutes = Int(pace)
-        let seconds = Int((pace - Double(minutes)) * 60)
-        return String(format: "%d:%02d/km", minutes, seconds)
     }
     
     // Helper function to convert pace string to seconds for sorting

--- a/flash/flashApp.swift
+++ b/flash/flashApp.swift
@@ -24,7 +24,7 @@ struct flashApp: App {
             ContentView()
                 .environmentObject(manager)
         }
-        .modelContainer(for: [CachedRunSummary.self])
+        .modelContainer(for: [CachedRunSummary.self, RunnerProfile.self])
     }
 }
 

--- a/flash/flashApp.swift
+++ b/flash/flashApp.swift
@@ -24,7 +24,7 @@ struct flashApp: App {
             ContentView()
                 .environmentObject(manager)
         }
-        .modelContainer(for: [CachedRunSummary.self, RunnerProfile.self])
+        .modelContainer(for: [CachedRunSummary.self, RunnerProfile.self, PersonalRecord.self])
     }
 }
 

--- a/flash/statsView.swift
+++ b/flash/statsView.swift
@@ -19,19 +19,21 @@ struct statsView: View {
                 Text("Splits")
                     .font(Font.custom("CallingCode-Regular", size: 24))
                     .padding(.bottom, 16)
-                HStack {
+                HStack(spacing: 8) {
                     Text("Km")
-                        .padding(.bottom, 8)
+                        .frame(width: 20, alignment: .leading)
+
+                    Text("Pace")
+                        .frame(width: 60, alignment: .leading)
 
                     Spacer()
-                    Text("Pace")
                 }
                 .font(Font.custom("CallingCode-Regular", size: 18))
                 .padding(.horizontal)
                 .padding(.bottom, 8)
 
                 ForEach(workout.pacePerKM, id: \.kilometer) { segment in
-                    HStack {
+                    HStack(spacing: 8) {
                         Text("\(segment.kilometer)")
                             .font(Font.custom("CallingCode-Regular", size: 18))
                             .frame(width: 20, alignment: .leading)

--- a/flash/statsView.swift
+++ b/flash/statsView.swift
@@ -327,7 +327,11 @@ struct statsView: View {
             .padding(.vertical)
             .frame(maxWidth: .infinity)
         }
-        .background(Color.flashBackground)
+        .background {
+            Color.flashBackground
+                .ignoresSafeArea()
+        }
+        .foregroundStyle(.white)
         .toolbarBackground(Color.flashBackground, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .onAppear {


### PR DESCRIPTION
## Summary

- add a persistent runner analytics profile with heart-rate, TRIMP, and preferred-distance settings
- add cache-backed monthly and yearly running trends with kilometer/mile presentation
- add deterministic whole-run personal records that navigate to lazily hydrated workout details
- keep workout detail and advanced-stat styling consistent, including aligned split pace columns

## Why

This begins Plan 002 by making the app's full running history useful for personalized analytics without repeatedly querying every HealthKit workout. The cached summaries remain rebuildable while HealthKit stays the source of truth.

## User impact

Runners can configure analytics preferences, review full-history trends, and open their longest, fastest, and highest-elevation runs from a Personal Records screen. Workout details and advanced stats retain the app's established dark styling.

## Validation

- built and launched on a connected iPhone 16 Pro
- exercised Settings validation and persistence
- verified monthly/yearly trends and kilometer/mile conversions
- verified Personal Record navigation and lazy HealthKit detail hydration
- verified Workout Details and Advanced Stats visually through iPhone Mirroring
- 22 unit tests passed with 0 failures
- Swift parser and `git diff --check` passed

## Scope

This PR covers Plan 002 slices 2A–2C. Resumable route-based personal-record backfilling is intentionally left for the next slice.