### PR TITLE
Add run cards and GPX export

### DIFF
--- a/flash/DetailedRun.swift
+++ b/flash/DetailedRun.swift
@@ -19,10 +19,22 @@ struct DetailedRun: View {
     @State private var displayedWorkout: RunningData
     @State private var region: MKCoordinateRegion
     @State private var isLoadingDetails = false
+    @State private var hasFinishedDetailHydration: Bool
+    @State private var isPreparingShare = false
+    @State private var pendingShareAction: RunShareAction?
+    @State private var isShowingShareConfirmation = false
+    @State private var preparedShare: PreparedRunShare?
+    @State private var sharingAlert: RunSharingAlert?
         
         init(workout: RunningData) {
             self.workout = workout
             _displayedWorkout = State(initialValue: workout)
+            _hasFinishedDetailHydration = State(
+                initialValue: !workout.route.isEmpty
+                    || !workout.heartRateData.isEmpty
+                    || !workout.cadenceData.isEmpty
+                    || !workout.pacePerKM.isEmpty
+            )
             if let firstLocation = workout.route.first {
                 _region = State(initialValue: MKCoordinateRegion(
                     center: firstLocation.coordinate,
@@ -114,6 +126,75 @@ struct DetailedRun: View {
         .navigationTitle("Workout Details")
         .toolbarBackground(Color.flashBackground, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button {
+                        requestShare(.card)
+                    } label: {
+                        Label("Share Run Card", systemImage: "photo")
+                    }
+                    .disabled(
+                        isLoadingDetails
+                            || !hasFinishedDetailHydration
+                            || isPreparingShare
+                    )
+
+                    Button {
+                        requestShare(.gpx)
+                    } label: {
+                        Label("Export GPX", systemImage: "map")
+                    }
+                    .disabled(
+                        isLoadingDetails
+                            || !hasFinishedDetailHydration
+                            || isPreparingShare
+                            || displayedWorkout.route.isEmpty
+                    )
+
+                    if hasFinishedDetailHydration
+                        && !isLoadingDetails
+                        && displayedWorkout.route.isEmpty {
+                        Text("GPX unavailable without a route")
+                    }
+                } label: {
+                    if isPreparingShare {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+                .disabled(isPreparingShare)
+                .accessibilityLabel(isPreparingShare ? "Preparing share" : "Share run")
+            }
+        }
+        .confirmationDialog(
+            pendingShareAction?.confirmationTitle ?? "Share this run?",
+            isPresented: $isShowingShareConfirmation,
+            titleVisibility: .visible
+        ) {
+            if let pendingShareAction {
+                Button(pendingShareAction.actionTitle) {
+                    prepareShare(pendingShareAction)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let pendingShareAction {
+                Text(pendingShareAction.privacyMessage)
+            }
+        }
+        .sheet(item: $preparedShare) { preparedShare in
+            PreparedRunShareView(preparedShare: preparedShare)
+        }
+        .alert(item: $sharingAlert) { alert in
+            Alert(
+                title: Text("Sharing Failed"),
+                message: Text(alert.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
         
         .onAppear {
             setRegionToFitRoute()
@@ -125,6 +206,52 @@ struct DetailedRun: View {
 
     private func metricText(_ value: Double) -> String {
         value > 0 ? String(format: "%.2f", value) : "N/A"
+    }
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
+
+    private func requestShare(_ action: RunShareAction) {
+        guard !isPreparingShare else { return }
+        pendingShareAction = action
+        isShowingShareConfirmation = true
+    }
+
+    private func prepareShare(_ action: RunShareAction) {
+        guard !isPreparingShare else { return }
+        isPreparingShare = true
+        pendingShareAction = nil
+
+        Task { @MainActor in
+            do {
+                let result: PreparedRunShare
+                switch action {
+                case .card:
+                    let document = try await ShareCardRenderer.makeDocument(
+                        run: displayedWorkout,
+                        unitPresentation: unitPresentation
+                    )
+                    result = .card(document)
+                case .gpx:
+                    let document = try GPXDocument(
+                        route: displayedWorkout.route,
+                        heartRate: displayedWorkout.heartRateData,
+                        name: "Run on \(displayedWorkout.date.formatted(date: .abbreviated, time: .shortened))",
+                        date: displayedWorkout.date
+                    )
+                    result = .gpx(document)
+                }
+
+                preparedShare = result
+            } catch {
+                sharingAlert = RunSharingAlert(message: error.localizedDescription)
+            }
+            isPreparingShare = false
+        }
     }
 
     private func loadWorkoutDetailsIfNeeded() async {
@@ -148,6 +275,7 @@ struct DetailedRun: View {
         await MainActor.run {
             displayedWorkout = hydratedWorkout
             isLoadingDetails = false
+            hasFinishedDetailHydration = true
             setRegionToFitRoute()
         }
     }

--- a/flash/GPXExport.swift
+++ b/flash/GPXExport.swift
@@ -1,0 +1,191 @@
+import CoreLocation
+import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+
+enum GPXExportError: LocalizedError, Equatable {
+    case emptyRoute
+    case invalidCoordinate(index: Int)
+    case encodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyRoute:
+            "This run does not have a route to export."
+        case .invalidCoordinate:
+            "The route contains a location that cannot be exported."
+        case .encodingFailed:
+            "Flash could not encode this run as GPX."
+        }
+    }
+}
+
+enum GPXExporter {
+    static func makeGPX(
+        route: [CLLocation],
+        heartRate: [HeartRateDataPoint],
+        name: String
+    ) throws -> String {
+        guard !route.isEmpty else {
+            throw GPXExportError.emptyRoute
+        }
+
+        let sortedRoute = route.sorted { $0.timestamp < $1.timestamp }
+        for (index, location) in sortedRoute.enumerated() {
+            let coordinate = location.coordinate
+            guard coordinate.latitude.isFinite,
+                  coordinate.longitude.isFinite,
+                  (-90.0...90.0).contains(coordinate.latitude),
+                  coordinate.longitude >= -180.0,
+                  coordinate.longitude < 180.0 else {
+                throw GPXExportError.invalidCoordinate(index: index)
+            }
+        }
+
+        let validHeartRates = heartRate
+            .compactMap { point -> ValidHeartRate? in
+                guard point.heartRate.isFinite else { return nil }
+                let roundedValue = Int(point.heartRate.rounded())
+                guard (1...255).contains(roundedValue) else { return nil }
+                return ValidHeartRate(timestamp: point.timestamp, value: roundedValue)
+            }
+            .sorted { $0.timestamp < $1.timestamp }
+        let timestampFormatter = makeTimestampFormatter()
+
+        var lines = [
+            #"<?xml version="1.0" encoding="UTF-8"?>"#,
+            #"<gpx version="1.1" creator="Flash" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">"#,
+            "  <trk>",
+            "    <name>\(escapeXML(name))</name>",
+            "    <trkseg>"
+        ]
+
+        for location in sortedRoute {
+            let coordinate = location.coordinate
+            lines.append(
+                "      <trkpt lat=\"\(decimal(coordinate.latitude, places: 8))\" lon=\"\(decimal(coordinate.longitude, places: 8))\">"
+            )
+
+            if location.altitude.isFinite {
+                lines.append("        <ele>\(decimal(location.altitude, places: 2))</ele>")
+            }
+            lines.append("        <time>\(timestampFormatter.string(from: location.timestamp))</time>")
+
+            if let nearest = nearestHeartRate(to: location.timestamp, in: validHeartRates) {
+                lines.append("        <extensions>")
+                lines.append("          <gpxtpx:TrackPointExtension>")
+                lines.append("            <gpxtpx:hr>\(nearest.value)</gpxtpx:hr>")
+                lines.append("          </gpxtpx:TrackPointExtension>")
+                lines.append("        </extensions>")
+            }
+
+            lines.append("      </trkpt>")
+        }
+
+        lines.append(contentsOf: [
+            "    </trkseg>",
+            "  </trk>",
+            "</gpx>"
+        ])
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    static func filename(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd-HHmm"
+        return "Flash-Run-\(formatter.string(from: date)).gpx"
+    }
+
+    private struct ValidHeartRate {
+        let timestamp: Date
+        let value: Int
+    }
+
+    private static func nearestHeartRate(
+        to timestamp: Date,
+        in samples: [ValidHeartRate]
+    ) -> ValidHeartRate? {
+        guard !samples.isEmpty else { return nil }
+
+        var lowerBound = 0
+        var upperBound = samples.count
+        while lowerBound < upperBound {
+            let middle = lowerBound + (upperBound - lowerBound) / 2
+            if samples[middle].timestamp < timestamp {
+                lowerBound = middle + 1
+            } else {
+                upperBound = middle
+            }
+        }
+
+        if lowerBound == 0 { return samples[0] }
+        if lowerBound == samples.count { return samples[samples.count - 1] }
+
+        let before = samples[lowerBound - 1]
+        let after = samples[lowerBound]
+        let beforeDistance = abs(timestamp.timeIntervalSince(before.timestamp))
+        let afterDistance = abs(after.timestamp.timeIntervalSince(timestamp))
+        return beforeDistance <= afterDistance ? before : after
+    }
+
+    private static func decimal(_ value: Double, places: Int) -> String {
+        String(
+            format: "%.*f",
+            locale: Locale(identifier: "en_US_POSIX"),
+            places,
+            value
+        )
+    }
+
+    private static func makeTimestampFormatter() -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }
+
+    private static func escapeXML(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+}
+
+extension UTType {
+    static let gpx = UTType(filenameExtension: "gpx", conformingTo: .xml) ?? .xml
+}
+
+struct GPXDocument: Transferable {
+    let data: Data
+    let filename: String
+
+    init(route: [CLLocation], heartRate: [HeartRateDataPoint], name: String, date: Date) throws {
+        let xml = try GPXExporter.makeGPX(route: route, heartRate: heartRate, name: name)
+        guard let data = xml.data(using: .utf8) else {
+            throw GPXExportError.encodingFailed
+        }
+        self.data = data
+        self.filename = GPXExporter.filename(for: date)
+    }
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .gpx) { document in
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            let url = directory.appendingPathComponent(document.filename)
+            try document.data.write(to: url, options: .atomic)
+            return SentTransferredFile(url)
+        }
+    }
+}

--- a/flash/RunSharing.swift
+++ b/flash/RunSharing.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+enum RunShareAction {
+    case card
+    case gpx
+
+    var confirmationTitle: String {
+        switch self {
+        case .card: "Share this run card?"
+        case .gpx: "Export this run as GPX?"
+        }
+    }
+
+    var actionTitle: String {
+        switch self {
+        case .card: "Prepare Run Card"
+        case .gpx: "Prepare GPX Export"
+        }
+    }
+
+    var privacyMessage: String {
+        switch self {
+        case .card:
+            "The card may show your route on a map along with workout stats."
+        case .gpx:
+            "The GPX file contains your precise route, timestamps, elevation, and available heart-rate data."
+        }
+    }
+}
+
+enum PreparedRunShare: Identifiable {
+    case card(ShareCardDocument)
+    case gpx(GPXDocument)
+
+    var id: String {
+        switch self {
+        case .card: "card"
+        case .gpx: "gpx"
+        }
+    }
+}
+
+struct RunSharingAlert: Identifiable {
+    let id = UUID()
+    let message: String
+}
+
+struct PreparedRunShareView: View {
+    @Environment(\.dismiss) private var dismiss
+    let preparedShare: PreparedRunShare
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                switch preparedShare {
+                case .card(let document):
+                    if let previewImage = document.previewImage {
+                        Image(uiImage: previewImage)
+                            .resizable()
+                            .scaledToFit()
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .accessibilityLabel("Preview of the run card")
+
+                        ShareLink(
+                            item: document,
+                            preview: SharePreview(
+                                document.filename,
+                                image: Image(uiImage: previewImage)
+                            )
+                        ) {
+                            shareButtonLabel(
+                                "Open Share Sheet",
+                                systemImage: "square.and.arrow.up"
+                            )
+                        }
+                    } else {
+                        Text("The run-card preview is unavailable.")
+                            .foregroundStyle(.red)
+                    }
+
+                case .gpx(let document):
+                    Image(systemName: "map")
+                        .font(.system(size: 56))
+                        .foregroundStyle(.white.opacity(0.85))
+                        .accessibilityHidden(true)
+
+                    Text(document.filename)
+                        .font(Font.custom("CallingCode-Regular", size: 17))
+                        .multilineTextAlignment(.center)
+
+                    Text("Contains your precise route and available workout measurements.")
+                        .font(Font.custom("CallingCode-Regular", size: 13))
+                        .foregroundStyle(.white.opacity(0.65))
+                        .multilineTextAlignment(.center)
+
+                    ShareLink(
+                        item: document,
+                        preview: SharePreview(
+                            document.filename,
+                            icon: Image(systemName: "map")
+                        )
+                    ) {
+                        shareButtonLabel("Open Share Sheet", systemImage: "square.and.arrow.up")
+                    }
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.flashBackground.ignoresSafeArea())
+            .foregroundStyle(.white)
+            .navigationTitle("Ready to Share")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func shareButtonLabel(_ title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(Font.custom("CallingCode-Regular", size: 18))
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.white.opacity(0.14))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/flash/ShareCard.swift
+++ b/flash/ShareCard.swift
@@ -1,0 +1,283 @@
+import CoreTransferable
+import Foundation
+import MapKit
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+enum ShareCardError: LocalizedError {
+    case renderingFailed
+
+    var errorDescription: String? {
+        "Flash could not render the run card."
+    }
+}
+
+struct ShareCardDocument: Transferable {
+    let data: Data
+    let filename: String
+
+    var previewImage: UIImage? {
+        UIImage(data: data)
+    }
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .png) { document in
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            let url = directory.appendingPathComponent(document.filename)
+            try document.data.write(to: url, options: .atomic)
+            return SentTransferredFile(url)
+        }
+    }
+}
+
+struct ShareCardView: View {
+    let run: RunningData
+    let unitPresentation: RunUnitPresentation
+    let mapImage: UIImage?
+
+    var body: some View {
+        ZStack {
+            Color.flashBackground
+
+            if let mapImage {
+                Image(uiImage: mapImage)
+                    .resizable()
+                    .scaledToFill()
+                    .overlay {
+                        LinearGradient(
+                            colors: [
+                                Color.black.opacity(0.12),
+                                Color.flashBackground.opacity(0.18),
+                                Color.flashBackground.opacity(0.96)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    }
+            } else {
+                statsOnlyBackground
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("FLASH")
+                        .font(Font.custom("CallingCode-Regular", size: 26))
+                        .tracking(3)
+                    Spacer()
+                    Text(run.date.formatted(.dateTime.month(.abbreviated).day().year()))
+                        .font(Font.custom("CallingCode-Regular", size: 14))
+                }
+
+                Spacer()
+
+                Text("RUN")
+                    .font(Font.custom("CallingCode-Regular", size: 14))
+                    .foregroundStyle(.white.opacity(0.65))
+                    .tracking(2)
+
+                Text(unitPresentation.distanceText(fromMeters: run.distance))
+                    .font(Font.custom("CallingCode-Regular", size: 48))
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(1)
+
+                HStack(spacing: 24) {
+                    stat(
+                        title: "TIME",
+                        value: RunUnitPresentation.durationText(run.duration)
+                    )
+                    stat(
+                        title: "PACE",
+                        value: unitPresentation.paceText(
+                            fromMinutesPerKilometer: paceMinutesPerKilometer
+                        )
+                    )
+                    if run.heartRate.isFinite, run.heartRate > 0 {
+                        stat(
+                            title: "AVG HR",
+                            value: "\(Int(run.heartRate.rounded())) bpm"
+                        )
+                    }
+                }
+                .padding(.top, 18)
+            }
+            .padding(28)
+        }
+        .foregroundStyle(.white)
+        .frame(width: 360, height: 450)
+        .clipped()
+    }
+
+    private var statsOnlyBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.flashBackground, Color.black.opacity(0.42)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            Circle()
+                .stroke(Color.white.opacity(0.08), lineWidth: 34)
+                .frame(width: 310, height: 310)
+                .offset(x: 130, y: -150)
+
+            Circle()
+                .stroke(Color.white.opacity(0.05), lineWidth: 20)
+                .frame(width: 220, height: 220)
+                .offset(x: -160, y: 190)
+        }
+    }
+
+    private var paceMinutesPerKilometer: Double {
+        guard run.distance.isFinite,
+              run.duration.isFinite,
+              run.distance > 0,
+              run.duration > 0 else {
+            return 0
+        }
+        return (run.duration / 60) / (run.distance / 1_000)
+    }
+
+    private func stat(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(Font.custom("CallingCode-Regular", size: 11))
+                .foregroundStyle(.white.opacity(0.62))
+                .tracking(1)
+            Text(value)
+                .font(Font.custom("CallingCode-Regular", size: 16))
+                .minimumScaleFactor(0.72)
+                .lineLimit(1)
+        }
+    }
+}
+
+enum ShareCardRenderer {
+    @MainActor
+    static func makeDocument(
+        run: RunningData,
+        unitPresentation: RunUnitPresentation
+    ) async throws -> ShareCardDocument {
+        let mapImage = await RouteSnapshotRenderer.image(
+            for: run.route,
+            size: CGSize(width: 360, height: 450)
+        )
+        let card = ShareCardView(
+            run: run,
+            unitPresentation: unitPresentation,
+            mapImage: mapImage
+        )
+        let renderer = ImageRenderer(content: card)
+        renderer.proposedSize = ProposedViewSize(width: 360, height: 450)
+        renderer.scale = 3
+        renderer.isOpaque = true
+
+        guard let image = renderer.uiImage,
+              let data = image.pngData() else {
+            throw ShareCardError.renderingFailed
+        }
+
+        return ShareCardDocument(
+            data: data,
+            filename: filename(for: run.date)
+        )
+    }
+
+    private static func filename(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd-HHmm"
+        return "Flash-Run-\(formatter.string(from: date)).png"
+    }
+}
+
+@MainActor
+private enum RouteSnapshotRenderer {
+    static func image(for route: [CLLocation], size: CGSize) async -> UIImage? {
+        let validRoute = route
+            .filter {
+                let coordinate = $0.coordinate
+                return CLLocationCoordinate2DIsValid(coordinate)
+                    && coordinate.latitude.isFinite
+                    && coordinate.longitude.isFinite
+            }
+            .sorted { $0.timestamp < $1.timestamp }
+        guard !validRoute.isEmpty else { return nil }
+
+        let options = MKMapSnapshotter.Options()
+        options.mapType = .mutedStandard
+        options.size = size
+        options.scale = 3
+        options.mapRect = paddedMapRect(for: validRoute)
+
+        let snapshotter = MKMapSnapshotter(options: options)
+        return await withCheckedContinuation { continuation in
+            snapshotter.start { snapshot, error in
+                guard error == nil, let snapshot else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: draw(route: validRoute, on: snapshot))
+            }
+        }
+    }
+
+    private static func paddedMapRect(for route: [CLLocation]) -> MKMapRect {
+        var mapRect = MKMapRect.null
+        for location in route {
+            let point = MKMapPoint(location.coordinate)
+            let pointRect = MKMapRect(x: point.x, y: point.y, width: 0.1, height: 0.1)
+            mapRect = mapRect.union(pointRect)
+        }
+
+        let horizontalPadding = max(mapRect.size.width * 0.18, 1_200)
+        let verticalPadding = max(mapRect.size.height * 0.18, 1_200)
+        return mapRect.insetBy(dx: -horizontalPadding, dy: -verticalPadding)
+    }
+
+    private static func draw(
+        route: [CLLocation],
+        on snapshot: MKMapSnapshotter.Snapshot
+    ) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: snapshot.image.size)
+        return renderer.image { context in
+            snapshot.image.draw(at: .zero)
+
+            let path = UIBezierPath()
+            for (index, location) in route.enumerated() {
+                let point = snapshot.point(for: location.coordinate)
+                if index == 0 {
+                    path.move(to: point)
+                } else {
+                    path.addLine(to: point)
+                }
+            }
+
+            context.cgContext.setLineCap(.round)
+            context.cgContext.setLineJoin(.round)
+            context.cgContext.setStrokeColor(UIColor.black.withAlphaComponent(0.5).cgColor)
+            context.cgContext.setLineWidth(10)
+            context.cgContext.addPath(path.cgPath)
+            context.cgContext.strokePath()
+
+            context.cgContext.setStrokeColor(UIColor.white.cgColor)
+            context.cgContext.setLineWidth(6)
+            context.cgContext.addPath(path.cgPath)
+            context.cgContext.strokePath()
+
+            if route.count == 1, let location = route.first {
+                let point = snapshot.point(for: location.coordinate)
+                let markerRect = CGRect(x: point.x - 6, y: point.y - 6, width: 12, height: 12)
+                context.cgContext.setFillColor(UIColor.white.cgColor)
+                context.cgContext.fillEllipse(in: markerRect)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a GPX 1.1 exporter with chronological route sorting, locale-stable coordinates, XML escaping, UTC timestamps, bounded Garmin heart-rate extensions, and typed file transfer
- add branded 1080×1350 run cards that respect the saved km/mi preference and render either a route snapshot or a stats-only fallback
- add a compact sharing menu to workout details with hydration gating, privacy confirmation, progress/error states, and prepared-file previews
- keep the feature local-first with no persistence migration, backend, cloud upload, or new entitlement

## Why

Sharing was planned as Flash's data-portability and organic-growth feature. The original plan predated the local-first and analytics work, so this implementation reconciles the current detail hydration path, runner unit preference, sensitive route/health data, and the fact that HealthKit route batches may arrive out of order.

## Validation

- Xcode device build passed with the connected iPhone 16 as the active destination
- all 26 XCTest cases passed on the physical iPhone, including four GPX-specific cases
- a real routed workout produced the privacy prompt, branded card preview, timestamped PNG, and native iOS share sheet
- the same workout produced the GPX disclosure, timestamped GPX preview, and native iOS share sheet
- both share sheets were dismissed without saving or transmitting workout data
- a standalone GPX harness verified route ordering, XML escaping, and HR rounding; the generated document passed `xmllint`
- `Info.plist` and entitlements pass `plutil -lint`
- `git diff --check origin/main...HEAD` passes

The build still reports the repository's existing Sentry script-output warning and two existing `HealthManager` Sendable-capture warnings; this change adds no compiler errors or new warnings.

## Follow-up manual QA

Core device behavior is verified. Before release, it is still worth spot-checking a mile-profile card, a workout with no route, offline map fallback, rapid repeated taps/cancellation, VoiceOver labels, and importing the GPX into a preferred third-party fitness tool.

The local test files are intentionally not committed, following the repository's test-file policy.