### PR TITLE
Fix miles distance unit conversion

### DIFF
--- a/flash/DetailedRun.swift
+++ b/flash/DetailedRun.swift
@@ -57,11 +57,15 @@ struct DetailedRun: View {
                 }
             }
             
-            Text("Distance: \(displayedWorkout.distance / 1000, specifier: "%.2f") km")
+            Text(
+                "Distance: \(unitPresentation.distanceText(fromMeters: displayedWorkout.distance))"
+            )
                 .font(Font.custom("CallingCode-Regular", size: 20))
             Text("Duration: \(displayedWorkout.formatDuration)")
                 .font(Font.custom("CallingCode-Regular", size: 20))
-            Text("Average Pace: \(displayedWorkout.formattedPace)")
+            Text(
+                "Average Pace: \(unitPresentation.paceText(fromMinutesPerKilometer: paceMinutesPerKilometer))"
+            )
                 .font(Font.custom("CallingCode-Regular", size: 20))
             
             HStack{
@@ -84,7 +88,11 @@ struct DetailedRun: View {
               
                 VStack{
                     Text("Elevation")
-                    Text(metricText(displayedWorkout.elevation))
+                    Text(
+                        displayedWorkout.elevation > 0
+                            ? unitPresentation.elevationText(fromMeters: displayedWorkout.elevation)
+                            : "N/A"
+                    )
                 }.frame(width: 100)
             }.font(Font.custom("CallingCode-Regular", size: 20))
                 //.frame(alignment: .trailing)
@@ -125,6 +133,23 @@ struct DetailedRun: View {
 
     private func metricText(_ value: Double) -> String {
         value > 0 ? String(format: "%.2f", value) : "N/A"
+    }
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
+
+    private var paceMinutesPerKilometer: Double {
+        guard displayedWorkout.distance.isFinite,
+              displayedWorkout.duration.isFinite,
+              displayedWorkout.distance > 0,
+              displayedWorkout.duration > 0 else {
+            return 0
+        }
+        return (displayedWorkout.duration / 60) / (displayedWorkout.distance / 1_000)
     }
 
     private func loadWorkoutDetailsIfNeeded() async {

--- a/flash/GraphData.swift
+++ b/flash/GraphData.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
-import SwiftUI
 import Charts
+import SwiftData
+import SwiftUI
 
 //data for the graph on the home page
 //day will be from apple health
@@ -21,6 +22,14 @@ struct WeeklyRunData: Identifiable {
 
 struct ChartsView: View {
     @EnvironmentObject var manager: HealthManager
+    @Query private var profiles: [RunnerProfile]
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
     
     var body: some View {
         VStack {
@@ -32,7 +41,12 @@ struct ChartsView: View {
                     let dailyData = manager.weeklyRunSummery.first { Calendar.current.isDate($0.date, inSameDayAs: date) }
                     BarMark(
                         x: .value("Day", date.startOfWeekFormatted()),
-                        y: .value("Kilometers Ran", dailyData?.kmRan ?? 0)
+                        y: .value(
+                            "\(unitPresentation.unit.title) Ran",
+                            unitPresentation.distance(
+                                fromMeters: (dailyData?.kmRan ?? 0) * 1_000
+                            )
+                        )
                     )
                 }
             }

--- a/flash/HealthManager.swift
+++ b/flash/HealthManager.swift
@@ -344,42 +344,58 @@ class HealthManager: ObservableObject {
         }
     }
 
-    func calculatePacePerKM(route: [CLLocation], totalDuration: TimeInterval) -> [SegmentPace] {
-            guard !route.isEmpty else { return [] }
+    func calculatePacePerKM(route: [CLLocation], totalDuration _: TimeInterval) -> [SegmentPace] {
+        calculatePaceSegments(route: route, segmentDistanceMeters: 1_000)
+    }
 
-            var segmentPaces: [SegmentPace] = []
-            var currentKilometer = 1
-            var segmentDistance: Double = 0.0
-            var segmentTime: TimeInterval = 0.0
-            var lastLocation = route.first!
+    func calculatePaceSegments(
+        route: [CLLocation],
+        segmentDistanceMeters: Double
+    ) -> [SegmentPace] {
+        guard segmentDistanceMeters.isFinite, segmentDistanceMeters > 0 else { return [] }
+        guard !route.isEmpty else { return [] }
 
-            for location in route.dropFirst() {
-                let distance = location.distance(from: lastLocation)
-                segmentDistance += distance
-                segmentTime += location.timestamp.timeIntervalSince(lastLocation.timestamp)
+        var segmentPaces: [SegmentPace] = []
+        var currentSegment = 1
+        var segmentDistance: Double = 0.0
+        var segmentTime: TimeInterval = 0.0
+        var lastLocation = route.first!
 
-                if segmentDistance >= 1000 {
-                    let pace = segmentTime / 60 / (segmentDistance / 1000)
-                    let formattedPace = formatPace(pace)
-                    let segmentPace = SegmentPace(kilometer: currentKilometer, pace: pace, formattedPace: formattedPace)
-                    segmentPaces.append(segmentPace)
-                    currentKilometer += 1
-                    segmentDistance = 0.0
-                    segmentTime = 0.0
-                }
+        for location in route.dropFirst() {
+            let distance = location.distance(from: lastLocation)
+            segmentDistance += distance
+            segmentTime += location.timestamp.timeIntervalSince(lastLocation.timestamp)
 
-                lastLocation = location
-            }
-
-            if segmentDistance > 0 {
-                let pace = segmentTime / 60.0 / (segmentDistance / 1000)
+            if segmentDistance >= segmentDistanceMeters {
+                let pace = segmentTime / 60 / (segmentDistance / 1000)
                 let formattedPace = formatPace(pace)
-                let segmentPace = SegmentPace(kilometer: currentKilometer, pace: pace, formattedPace: formattedPace)
+                let segmentPace = SegmentPace(
+                    kilometer: currentSegment,
+                    pace: pace,
+                    formattedPace: formattedPace
+                )
                 segmentPaces.append(segmentPace)
+                currentSegment += 1
+                segmentDistance = 0.0
+                segmentTime = 0.0
             }
 
-            return segmentPaces
+            lastLocation = location
         }
+
+        if segmentDistance > 0 {
+            let pace = segmentTime / 60.0 / (segmentDistance / 1000)
+            let formattedPace = formatPace(pace)
+            let segmentPace = SegmentPace(
+                kilometer: currentSegment,
+                pace: pace,
+                formattedPace: formattedPace
+            )
+            segmentPaces.append(segmentPace)
+        }
+
+        return segmentPaces
+    }
 
     // Fetch heart rate data points over time during the workout
     private func fetchHeartRateTimeSeries(for workout: HKWorkout) async -> [HeartRateDataPoint] {

--- a/flash/SettingsView.swift
+++ b/flash/SettingsView.swift
@@ -140,12 +140,13 @@ struct SettingsView: View {
                     }
 
                     settingsCard(title: "Distance") {
-                        Picker("Preferred unit", selection: $draft.distanceUnit) {
+                        Picker("Preferred unit", selection: distanceUnitSelection) {
                             ForEach(PreferredDistanceUnit.allCases) { unit in
                                 Text(unit.title).tag(unit)
                             }
                         }
                         .pickerStyle(.segmented)
+                        .disabled(profile == nil)
                     }
 
                     if let validationMessage {
@@ -227,6 +228,16 @@ struct SettingsView: View {
         }
     }
 
+    private var distanceUnitSelection: Binding<PreferredDistanceUnit> {
+        Binding(
+            get: { draft.distanceUnit },
+            set: { unit in
+                draft.distanceUnit = unit
+                saveDistanceUnit(unit)
+            }
+        )
+    }
+
     @MainActor
     private func ensureProfileExists() {
         guard !hasLoadedProfile else { return }
@@ -273,6 +284,25 @@ struct SettingsView: View {
             isSaving = false
         } catch {
             statusMessage = error.localizedDescription
+            statusIsError = true
+        }
+    }
+
+    @MainActor
+    private func saveDistanceUnit(_ unit: PreferredDistanceUnit) {
+        guard let profile else { return }
+
+        let previousUnit = profile.distanceUnit
+        profile.distanceUnit = unit
+
+        do {
+            try modelContext.save()
+            statusMessage = "Distance unit updated."
+            statusIsError = false
+        } catch {
+            profile.distanceUnit = previousUnit
+            draft.distanceUnit = previousUnit
+            statusMessage = "Could not save distance unit: \(error.localizedDescription)"
             statusIsError = true
         }
     }

--- a/flash/TrendsView.swift
+++ b/flash/TrendsView.swift
@@ -270,7 +270,9 @@ struct TrendsView: View {
                 .font(Font.custom("CallingCode-Regular", size: 24))
 
             if pacePoints.isEmpty {
-                Text("Run at least 1 km to start a pace trend.")
+                Text(
+                    "Run at least \(unitPresentation.distanceText(fromMeters: 1_000)) to start a pace trend."
+                )
                     .font(Font.custom("CallingCode-Regular", size: 14))
                     .foregroundStyle(.white.opacity(0.6))
             } else {
@@ -307,7 +309,9 @@ struct TrendsView: View {
                 }
                 .frame(height: 240)
 
-                Text("Minutes\(unitPresentation.paceLabel) • runs shorter than 1 km excluded")
+                Text(
+                    "Minutes\(unitPresentation.paceLabel) • runs shorter than \(unitPresentation.distanceText(fromMeters: 1_000)) excluded"
+                )
                     .font(Font.custom("CallingCode-Regular", size: 12))
                     .foregroundStyle(.white.opacity(0.6))
             }

--- a/flash/WeeklySummery.swift
+++ b/flash/WeeklySummery.swift
@@ -5,22 +5,33 @@
 //  Created by abbe on 2024-04-12.
 //
 
+import SwiftData
 import SwiftUI
 
 
 
 struct WeeklySummery: View {
     @EnvironmentObject var manager: HealthManager
+    @Query private var profiles: [RunnerProfile]
     @State var stats: Stats
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
 
 //weekly run summery array of data 
 
     var body: some View {
             VStack{
                
-                Text("\(manager.weeklyRunDistance, specifier: "%.2f")")
+                Text(
+                    "\(unitPresentation.distance(fromMeters: manager.weeklyRunDistance * 1_000), specifier: "%.2f")"
+                )
                     .font(Font.custom("CallingCode-Regular", size: 96))
-                Text("kilometers")
+                Text(unitPresentation.unit.title.lowercased())
                     .font(Font.custom("CallingCode-Regular", size: 16))
                     .opacity(0.30)
                 VStack{
@@ -29,7 +40,11 @@ struct WeeklySummery: View {
                     Text("time")
                         .frame(maxWidth: 300, alignment: .leading)
                     
-                    Text(String(manager.formattedRunPace))
+                    Text(
+                        unitPresentation.paceText(
+                            fromMinutesPerKilometer: manager.weeklyRunPace
+                        )
+                    )
                         .frame(maxWidth: 300, alignment: .leading)
                         .padding(.top, 3)
                     Text("average pace")
@@ -42,4 +57,3 @@ struct WeeklySummery: View {
         
     }
 }
-

--- a/flash/detailsView.swift
+++ b/flash/detailsView.swift
@@ -82,7 +82,7 @@ struct detailsView: View {
                             title: "Longest Runs",
                             runs: manager.allRuns.sorted { $0.distance > $1.distance },
                             metric: { run in
-                                String(format: "%.2f km", run.distance / 1000)
+                                unitPresentation.distanceText(fromMeters: run.distance)
                             }
                         )
                     } label: {
@@ -100,11 +100,15 @@ struct detailsView: View {
                             runs: manager.allRuns
                                 .filter { $0.distance >= 1000 } // Only runs ≥ 1 km
                                 .sorted { first, second in
-                                    let pace1 = paceToSeconds(first.formattedPace)
-                                    let pace2 = paceToSeconds(second.formattedPace)
+                                    let pace1 = paceMinutesPerKilometer(for: first)
+                                    let pace2 = paceMinutesPerKilometer(for: second)
                                     return pace1 < pace2
                                 },
-                            metric: { $0.formattedPace }
+                            metric: { run in
+                                unitPresentation.paceText(
+                                    fromMinutesPerKilometer: paceMinutesPerKilometer(for: run)
+                                )
+                            }
                         )
                     } label: {
                         Text("Fastest Runs")
@@ -143,15 +147,14 @@ struct detailsView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
     }
     
-    // Helper function to convert pace string to seconds for sorting
-    private func paceToSeconds(_ paceString: String) -> Double {
-        let components = paceString.split(separator: ":")
-        if components.count == 2,
-           let minutes = Double(components[0]),
-           let seconds = Double(components[1].prefix(2)) {
-            return minutes * 60 + seconds
+    private func paceMinutesPerKilometer(for run: RunningData) -> Double {
+        guard run.distance.isFinite,
+              run.duration.isFinite,
+              run.distance > 0,
+              run.duration > 0 else {
+            return .infinity
         }
-        return Double.infinity
+        return (run.duration / 60) / (run.distance / 1_000)
     }
 }
 

--- a/flash/runsView.swift
+++ b/flash/runsView.swift
@@ -7,12 +7,21 @@
 
 import SwiftUI
 import HealthKit
+import SwiftData
 
 
 struct runsView: View {
     @EnvironmentObject var manager: HealthManager
+    @Query private var profiles: [RunnerProfile]
     @State private var hasLoadedInitialData = false
     @State private var scrollPosition: UUID?
+
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
     
     var body: some View {
         ZStack{
@@ -33,7 +42,11 @@ struct runsView: View {
                                         .month(.wide)
                                         .weekday(.wide)))
                                     .font(.headline)
-                                    Text("\(workout.distance / 1000, specifier: "%.2f") km")
+                                    Text(
+                                        unitPresentation.distanceText(
+                                            fromMeters: workout.distance
+                                        )
+                                    )
                                         .font(.subheadline)
                                 }
                                 .padding()
@@ -77,4 +90,3 @@ struct runsView: View {
         }
     }
 }
-

--- a/flash/statsView.swift
+++ b/flash/statsView.swift
@@ -4,23 +4,43 @@
 //
 //  Created by abbe on 2024-05-30.
 //
-import SwiftUI
 import Charts
+import SwiftData
+import SwiftUI
 
 //stats of run
 struct statsView: View {
+    @EnvironmentObject private var manager: HealthManager
+    @Query private var profiles: [RunnerProfile]
     let workout: RunningData
     @State private var cachedElevationSegments: [Double] = []
 
+    private var unitPresentation: RunUnitPresentation {
+        RunUnitPresentation(
+            unit: profiles.first { $0.key == RunnerProfile.singletonKey }?.distanceUnit
+                ?? .kilometers
+        )
+    }
+
+    private var displayedSplits: [SegmentPace] {
+        guard !workout.route.isEmpty else { return workout.pacePerKM }
+        let segmentDistance = unitPresentation.unit == .miles ? 1_609.344 : 1_000
+        return manager.calculatePaceSegments(
+            route: workout.route,
+            segmentDistanceMeters: segmentDistance
+        )
+    }
+
     var body: some View {
         let _ = print("🔍 StatsView loaded - Cadence data count: \(workout.cadenceData.count)")
+        let splits = displayedSplits
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Splits")
                     .font(Font.custom("CallingCode-Regular", size: 24))
                     .padding(.bottom, 16)
                 HStack(spacing: 8) {
-                    Text("Km")
+                    Text(unitPresentation.distanceLabel)
                         .frame(width: 20, alignment: .leading)
 
                     Text("Pace")
@@ -32,7 +52,7 @@ struct statsView: View {
                 .padding(.horizontal)
                 .padding(.bottom, 8)
 
-                ForEach(workout.pacePerKM, id: \.kilometer) { segment in
+                ForEach(splits, id: \.kilometer) { segment in
                     HStack(spacing: 8) {
                         Text("\(segment.kilometer)")
                             .font(Font.custom("CallingCode-Regular", size: 18))
@@ -40,13 +60,20 @@ struct statsView: View {
 
 
 
-                        Text(segment.formattedPace)
+                        Text(
+                            unitPresentation.paceText(
+                                fromMinutesPerKilometer: segment.pace
+                            )
+                        )
                             .font(Font.custom("CallingCode-Regular", size: 18))
                             .frame(width: 60, alignment: .leading)
 
                         Rectangle()
                             .fill(Color.blue)
-                            .frame(width: self.barWidth(for: segment.pace), height: 20)
+                            .frame(
+                                width: self.barWidth(for: segment.pace, among: splits),
+                                height: 20
+                            )
                             .cornerRadius(4)
 
                     }
@@ -69,13 +96,15 @@ struct statsView: View {
                     if let maxElevation = elevations.max(),
                        let minElevation = elevations.min() {
                         VStack(alignment: .trailing, spacing: 2) {
-                            Text("\(Int(maxElevation))m")
+                            Text(unitPresentation.elevationText(fromMeters: maxElevation))
                                 .font(Font.custom("CallingCode-Regular", size: 14))
                                 .foregroundColor(.green)
-                            Text("Avg: \(Int(elevations.average()))m")
+                            Text(
+                                "Avg: \(unitPresentation.elevationText(fromMeters: elevations.average()))"
+                            )
                                 .font(Font.custom("CallingCode-Regular", size: 14))
                                 .foregroundColor(.green.opacity(0.8))
-                            Text("\(Int(minElevation))m")
+                            Text(unitPresentation.elevationText(fromMeters: minElevation))
                                 .font(Font.custom("CallingCode-Regular", size: 14))
                                 .foregroundColor(.green.opacity(0.6))
                         }
@@ -145,7 +174,9 @@ struct statsView: View {
                     HStack {
                         Image(systemName: "arrow.up.right")
                             .foregroundColor(.green)
-                        Text("Total Elevation Gain: \(Int(workout.elevation))m")
+                        Text(
+                            "Total Elevation Gain: \(unitPresentation.elevationText(fromMeters: workout.elevation))"
+                        )
                             .font(Font.custom("CallingCode-Regular", size: 16))
                     }
                     .padding(.horizontal)
@@ -472,8 +503,8 @@ extension statsView {
     }
 
     // MARK: - Helper Functions
-    private func barWidth(for pace: Double) -> CGFloat {
-        let maxPace = workout.pacePerKM.map { $0.pace }.max() ?? 1
+    private func barWidth(for pace: Double, among splits: [SegmentPace]) -> CGFloat {
+        let maxPace = splits.map(\.pace).max() ?? 1
         let maxWidth: CGFloat = 200 // Fixed width for bars
 
         return CGFloat((pace / maxPace) * Double(maxWidth))


### PR DESCRIPTION
## Summary
- persist distance-unit selection immediately
- apply mile conversion across home, history, workout details, analytics, and trends
- calculate advanced splits at mile boundaries and display imperial elevation

## Verification
- parsed all Swift source files successfully
- verified 10.00 km displays as 6.21 mi and 5:00/km displays as 8:03/mi
- full iOS build/tests unavailable because this environment has Command Line Tools but not full Xcode